### PR TITLE
fix parsing CRLF files, part 3

### DIFF
--- a/read_test.go
+++ b/read_test.go
@@ -40,8 +40,6 @@ func readFixturesExample(t *testing.T, doc *testmark.Document) {
 }
 
 func TestParseCRLF(t *testing.T) {
-	t.Skip("currently broken")
-
 	input, err := ioutil.ReadFile(filepath.Join("testdata", "example.md"))
 	if err != nil {
 		t.Fatal(err)

--- a/testmark.go
+++ b/testmark.go
@@ -52,6 +52,11 @@ type Hunk struct {
 
 	// The full body of the hunk, as bytes.
 	// (This is *still* a subslice of Document.Original, if this hunk was created by Parse, but probably a unique slice otherwise.)
+	//
+	// When produced by Parse, the Body has been normalized to have '\n' linebreaks if it originally contained '\r\n'.
+	// This is meant as a practical conceit to the fact some systems in the Windows ecosystem tend to mutate documents when checking them out of version control,
+	// and thus testmark finds it practical to pave that back out that again rather than making it an application-level problem.
+	// (If such a normalization had to be applied, the earlier coment about subslicing of Document.Original probably no longer applies.)
 	Body []byte
 }
 


### PR DESCRIPTION
Nothing can be easy or nice, can it.

Dogpiling on https://github.com/warpfork/go-testmark/pull/4 and https://github.com/warpfork/go-testmark/pull/3 .  I think this is addressing the last of the things we've discovered through that journey.

Most of the diff is just me commenting crankily, as is natural.

On the plus side, some tests are unskipped now and actually hold up some standards and expectations.  That's nice.