### PR TITLE
testexec: getting exit codes correctly.

### DIFF
--- a/testexec/defaults.go
+++ b/testexec/defaults.go
@@ -3,6 +3,7 @@ package testexec
 import (
 	"io"
 	"os/exec"
+	"syscall"
 	"testing"
 )
 
@@ -12,8 +13,28 @@ func ExecFn_Exec(args []string, stdin io.Reader, stdout, stderr io.Writer) (exit
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	err := cmd.Run()
-	// FIXME: get the error code.
-	return -1, err
+	// A bunch of processing is required to get typical unix error codes out of golang's exec system, unfortunately.
+	// We're going to:
+	// - Try to return the exit code, if we can parse it -- and then *not* return an error.
+	// - Try to return a negative number with the signal if that's what killed things -- and then again *not* return an error.
+	// - Or return -1000 and an error, for anything else we can't make sense of.
+	// The -1000 return probably doesn't matter much -- you should check the error first (and where testmark uses this callback, it does),
+	//  but a non-zero value there seems like better defense-in-depth anyway.
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		waitStatus, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok {
+			return exitErr.ExitCode(), nil
+		}
+		if waitStatus.Exited() {
+			return waitStatus.ExitStatus(), nil
+		} else if waitStatus.Signaled() {
+			return -int(waitStatus.Signal()), nil
+		}
+	}
+	if err != nil {
+		return -1000, err
+	}
+	return 0, nil
 }
 
 func ScriptFn_ExecBash(script string, stdin io.Reader, stdout, stderr io.Writer) (exitcode int, oshit error) {


### PR DESCRIPTION
`ExecFn_Exec` and `ScriptFn_ExecBash` (the defaults) now return exit codes correctly.

I've gone perhaps a bit overboard in also making sure that death-by-signal is reported, too.  Maybe this won't stick around (especially because it requires importing the syscall packaage, which might otherwise be avoidable on recentish versions of golang), because I don't know if it's critically relevant and likely to actually get exercised much in this domain... but I've written it, so let's see if it sticks.