### PR TITLE
testexec: subtest ("then-*") feature

### DIFF
--- a/testexec/selfexercise.md
+++ b/testexec/selfexercise.md
@@ -1,0 +1,81 @@
+testexec selfexercise file
+==========================
+
+We will run a script with some files provisioned:
+
+[testmark]:# (whee/fs/a)
+```
+body-a
+```
+
+The script is simple:
+
+[testmark]:# (whee/script)
+```
+echo hello
+ls
+```
+
+The output is unsurprising:
+
+[testmark]:# (whee/output)
+```
+hello
+a
+```
+
+---
+
+We can make subtests which add more files:
+
+[testmark]:# (whee/then-more-files/fs/b)
+```
+body-b
+```
+
+[testmark]:# (whee/then-more-files/script)
+```
+ls
+```
+
+[testmark]:# (whee/then-more-files/output)
+```
+a
+b
+```
+
+---
+
+We can also affect the filesystem in subtests:
+
+[testmark]:# (whee/then-touching-files/script)
+```
+echo "body-c" > ./c
+ls
+```
+
+Notice that this doesn't inherit the file "b" from the last test --
+this is because they're siblings, so they each got a copy of the *parent* filesystem state.
+
+[testmark]:# (whee/then-touching-files/output)
+```
+a
+c
+```
+
+---
+
+If we make a subtest of *that* subtest, it also inherits a copy of those effects:
+
+[testmark]:# (whee/then-touching-files/then-subtesting-again/script)
+```
+ls
+cat ./c
+```
+
+[testmark]:# (whee/then-touching-files/then-subtesting-again/output)
+```
+a
+c
+body-c
+```

--- a/testexec/testexec.go
+++ b/testexec/testexec.go
@@ -205,8 +205,10 @@ func (tcfg Tester) test(t *testing.T, data testmark.DirEnt, allowExec, allowScri
 		}
 
 		// Create any new files.
-		if err := createFiles(fsEnt, "."); err != nil {
-			t.Errorf("test aborted: could not populate files to tempdir: %s", err)
+		if fsEnt != nil {
+			if err := createFiles(fsEnt, "."); err != nil {
+				t.Errorf("test aborted: could not populate files to tempdir: %s", err)
+			}
 		}
 	}
 

--- a/testexec/testexec_test.go
+++ b/testexec/testexec_test.go
@@ -1,0 +1,28 @@
+package testexec_test
+
+import (
+	"testing"
+
+	"github.com/warpfork/go-testmark"
+	"github.com/warpfork/go-testmark/testexec"
+)
+
+func Test(t *testing.T) {
+	filename := "selfexercise.md"
+	doc, err := testmark.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("spec file parse failed?!: %s", err)
+	}
+
+	doc.BuildDirIndex()
+	patches := testmark.PatchAccumulator{}
+	for _, dir := range doc.DirEnt.ChildrenList {
+		t.Run(dir.Name, func(t *testing.T) {
+			test := testexec.Tester{
+				Patches: &patches,
+			}
+			test.TestScript(t, dir)
+		})
+	}
+	patches.WriteFileWithPatches(doc, filename)
+}


### PR DESCRIPTION
With this feature, naming a hunk in the pattern of `{testname}/then-{subtestname}/script` (when there's already a `{testname}/script` hunk, so testexec is already in motion) will cause subtests to run.

Subtests are more of the same, but have one especially useful feature: they start within a working directory that's a copy of the files and directories that were in the working directory of the parent test after it was finished.

Subtests can be nested -- `{testname}/then-{subtestname}/then-{subsubtestname}/script` -- in which case each of them continues getting a copy of the filesystem from the test that came before them....

... or, subtests can fan out -- `{testname}/then-{subtestname}/script` and `{testname}/then-{othersubtestname}/script` -- in which case each of them gets a copy of the parent, but _separate copies_, which do not interfere with each other.

This should help a great deal in writing tests for programs that have filesystem state.  It can also be very useful for writing suites of tests for a program that needs some configuration files, and you don't want to repeat those every time: now you can just use the top level test to set up the config files, and then use a bunch of sibling subtests for all the actual testing work.

(This is itself... not yet tested.  Don't rely on this commit hash; this PR may be rebased.)