### PR TITLE
RFC: Describe function

### DIFF
--- a/read.go
+++ b/read.go
@@ -23,7 +23,12 @@ func ReadFile(name string) (*Document, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return Read(f)
+	doc, err := Read(f)
+	if err != nil {
+		return nil, err
+	}
+	doc.Path = name
+	return doc, nil
 }
 
 var (

--- a/read_test.go
+++ b/read_test.go
@@ -14,10 +14,12 @@ func TestRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	doc, err := testmark.ReadFile(filepath.Join(testdata, "example.md"))
+	path := filepath.Join(testdata, "example.md")
+	doc, err := testmark.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assert(t, doc.Path, path)
 
 	readFixturesExample(t, doc)
 }

--- a/testexec/testexec_test.go
+++ b/testexec/testexec_test.go
@@ -1,6 +1,7 @@
 package testexec_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/warpfork/go-testmark"
@@ -18,10 +19,12 @@ func Test(t *testing.T) {
 	patches := testmark.PatchAccumulator{}
 	for _, dir := range doc.DirEnt.ChildrenList {
 		t.Run(dir.Name, func(t *testing.T) {
+			t.Logf("testmark describe\n%s", strings.Join(doc.Describe(&dir), "\n"))
 			test := testexec.Tester{
 				Patches: &patches,
 			}
 			test.TestScript(t, dir)
+			t.Fatalf("forced failure")
 		})
 	}
 	patches.WriteFileWithPatches(doc, filename)


### PR DESCRIPTION
Here's a general idea for a Describe function which can help people figure out what is going on when they encounter failures in code using testmark.

Why?
1. _test failure_ will be most people's first experience with this tool and when that happens they will have no context on what is happening or how testmark works. Pointing them to the document source where the relevant code actually resides can go a long way in reducing initial friction.
2. Even having experience with testmark, it's still nice to have document markers in test failures so I can more easily find the thing I need to fix.

```
go test ./...
ok  	github.com/warpfork/go-testmark	(cached)
--- FAIL: Test (0.02s)
    --- FAIL: Test/whee (0.01s)
        testexec_test.go:22: testmark describe
            selfexercise.md:13:whee/script
            selfexercise.md:21:whee/output
            selfexercise.md:31:whee/then-more-files/fs/b
            selfexercise.md:36:whee/then-more-files/script
            selfexercise.md:41:whee/then-more-files/output
            selfexercise.md:51:whee/then-touching-files/script
            selfexercise.md:60:whee/then-touching-files/output
            selfexercise.md:6:whee/fs/a
            selfexercise.md:70:whee/then-touching-files/then-subtesting-again/script
            selfexercise.md:76:whee/then-touching-files/then-subtesting-again/output
        testexec_test.go:27: forced failure
    --- FAIL: Test/using-stdin (0.00s)
        testexec_test.go:22: testmark describe
            selfexercise.md:87:using-stdin/input
            selfexercise.md:93:using-stdin/script
            selfexercise.md:98:using-stdin/output
        testexec_test.go:27: forced failure
FAIL
FAIL	github.com/warpfork/go-testmark/testexec	0.018s
FAIL
```

Potential Improvements:
1. `testexec` doesn't have the information it needs to produce this sort of output at a more granular level. We could pass that information down and instrument throughout.
2. Add options to Describe for sorting, setting/excluding path, min/max depth, filters, etc.
3. Figure out what to do with empty paths. Not everything will be loaded via `ReadFile`.
4. Absolute paths by default? Or at least dereferencing instances of `./../*`?

Other use case:
1. In warpforge we just test formulas i.e. `test.md:xx:formula` and `test.md:xx:formula/runrecord`. The test could ask to describe the formula dir entirely, just the parent dir, or filter for `runrecord`.
