### PR TITLE
Index fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/warpfork/go-testmark
 
 go 1.16
+
+require (
+	github.com/frankban/quicktest v1.14.4 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	gopkg.in/errgo.v2 v2.1.0 // indirect
+)

--- a/index.go
+++ b/index.go
@@ -32,10 +32,11 @@ func (dirent *DirEnt) fill(pathSegs []string, hunk Hunk) {
 		next.fill(pathSegs[1:], hunk)
 	} else {
 		l := len(dirent.ChildrenList)
-		dirent.ChildrenList = append(dirent.ChildrenList, DirEnt{
+		child := DirEnt{
 			Name: pathSegs[0],
-		})
-		dirent.Children[pathSegs[0]] = &dirent.ChildrenList[l]
+		}
+		dirent.ChildrenList = append(dirent.ChildrenList, &child)
+		dirent.Children[pathSegs[0]] = &child
 		dirent.ChildrenList[l].fill(pathSegs[1:], hunk)
 	}
 }

--- a/index_test.go
+++ b/index_test.go
@@ -2,7 +2,10 @@ package testmark
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 func TestIndexingDirs(t *testing.T) {
@@ -11,12 +14,16 @@ func TestIndexingDirs(t *testing.T) {
 		panic(err)
 	}
 	doc, err := ReadFile(filepath.Join(testdata, "exampleWithDirs.md"))
+	if err != nil {
+		panic(err)
+	}
 	doc.BuildDirIndex()
+
 	if len(doc.DirEnt.ChildrenList) != 2 {
-		t.Errorf("root dirent list should be length 2")
+		t.Errorf("root dirent list should be length 2 but was %d", len(doc.DirEnt.ChildrenList))
 	}
 	if len(doc.DirEnt.Children) != 2 {
-		t.Errorf("root dirent map should be length 2")
+		t.Errorf("root dirent map should be length 2 but was %d", len(doc.DirEnt.Children))
 	}
 	if doc.DirEnt.ChildrenList[0].Name != "one" {
 		t.Errorf("first child of root dirent should've been 'one'")
@@ -36,4 +43,78 @@ func TestIndexingDirs(t *testing.T) {
 	if string(doc.DirEnt.Children["really"].Children["deep"].Children["dirs"].Children["wow"].Hunk.Body) != "zot\n" {
 		t.Errorf("hunk 'really/deep/dirs/wow' looked up through dir maps should have the right content")
 	}
+}
+
+func TestIndexingTree(t *testing.T) {
+	testdata, err := filepath.Abs("testdata")
+	qt.Assert(t, err, qt.IsNil)
+	doc, err := ReadFile(filepath.Join(testdata, "exampleWithDirs.md"))
+	if err != nil {
+		panic(err)
+	}
+	if len(doc.DataHunks) != len(doc.HunksByName) {
+		t.Errorf("doc hunk list has different length than hunks-by-name: %d != %d", len(doc.DataHunks), len(doc.HunksByName))
+	}
+	doc.BuildDirIndex()
+
+	qt.Assert(t, len(doc.DataHunks), qt.Equals, len(doc.HunksByName))
+	for _, hunk := range doc.DataHunks {
+		t.Run("index:"+hunk.Name, func(t *testing.T) {
+			assertHunkReachable(t, doc, hunk)
+		})
+	}
+	assertChildren(t, *doc.DirEnt)
+}
+
+func assertHunkReachable(t *testing.T, doc *Document, hunk DocHunk) {
+	splits := strings.Split(hunk.Name, "/")
+	dir := doc.DirEnt
+	for _, s := range splits {
+		qt.Assert(t, len(dir.Children), qt.Equals, len(dir.ChildrenList))
+		d, ok := dir.Children[s]
+		qt.Assert(t, ok, qt.IsTrue)
+		dir = d
+	}
+	qt.Assert(t, &hunk.Hunk, qt.DeepEquals, dir.Hunk)
+}
+
+func assertChildren(t *testing.T, dir DirEnt) {
+	cm := make(map[string]struct{})
+	for _, child := range dir.ChildrenList {
+		{
+			// Check that a child of this name has not been found already
+			_, exists := cm[child.Name]
+			qt.Check(t, exists, qt.IsFalse, qt.Commentf("duplicate child"))
+			cm[child.Name] = struct{}{}
+		}
+		{
+			// Check that the child in the list exists in the child map
+			_, exists := dir.Children[child.Name]
+			qt.Check(t, exists, qt.IsTrue)
+		}
+		assertChildren(t, child)
+	}
+	qt.Check(t, len(dir.Children), qt.Equals, len(dir.ChildrenList),
+		// If the lengths are equal then the map and list should contain entries with the same names.
+		// We don't know if the dir entries are _actually_ equivalent but the test recurses above so it should be fine.
+		qt.Commentf("%s", dir.Name),
+		qt.Commentf("list: %v", names(dir.ChildrenList)),
+		qt.Commentf("keys: %v", keys(dir.Children)),
+	)
+}
+
+func keys(dirs map[string]*DirEnt) []string {
+	names := make([]string, 0, len(dirs))
+	for k := range dirs {
+		names = append(names, k)
+	}
+	return names
+}
+
+func names(dirs []DirEnt) []string {
+	names := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		names = append(names, d.Name)
+	}
+	return names
 }

--- a/index_test.go
+++ b/index_test.go
@@ -63,7 +63,7 @@ func TestIndexingTree(t *testing.T) {
 			assertHunkReachable(t, doc, hunk)
 		})
 	}
-	assertChildren(t, *doc.DirEnt)
+	assertChildren(t, doc.DirEnt)
 }
 
 func assertHunkReachable(t *testing.T, doc *Document, hunk DocHunk) {
@@ -78,7 +78,7 @@ func assertHunkReachable(t *testing.T, doc *Document, hunk DocHunk) {
 	qt.Assert(t, &hunk.Hunk, qt.DeepEquals, dir.Hunk)
 }
 
-func assertChildren(t *testing.T, dir DirEnt) {
+func assertChildren(t *testing.T, dir *DirEnt) {
 	cm := make(map[string]struct{})
 	for _, child := range dir.ChildrenList {
 		{
@@ -111,7 +111,7 @@ func keys(dirs map[string]*DirEnt) []string {
 	return names
 }
 
-func names(dirs []DirEnt) []string {
+func names(dirs []*DirEnt) []string {
 	names := make([]string, 0, len(dirs))
 	for _, d := range dirs {
 		names = append(names, d.Name)

--- a/read_test.go
+++ b/read_test.go
@@ -18,7 +18,9 @@ func TestRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	if len(doc.DataHunks) != len(doc.HunksByName) {
+		t.Errorf("document hunk list has different length than hunks-by-name: %d != %d", len(doc.DataHunks), len(doc.HunksByName))
+	}
 	readFixturesExample(t, doc)
 }
 

--- a/testexec/testexec.go
+++ b/testexec/testexec.go
@@ -309,7 +309,7 @@ func (tcfg Tester) test(t *testing.T, data testmark.DirEnt, allowExec, allowScri
 				if alreadyFailed {
 					t.Skipf("parent commands failed, so while more commands are specified, testing them is not meaningful")
 				}
-				tcfg.test(t, child, allowExec, allowScript, dir)
+				tcfg.test(t, *child, allowExec, allowScript, dir)
 			})
 		}
 	}

--- a/testexec/testexec_test.go
+++ b/testexec/testexec_test.go
@@ -21,7 +21,7 @@ func Test(t *testing.T) {
 			test := testexec.Tester{
 				Patches: &patches,
 			}
-			test.TestScript(t, dir)
+			test.TestScript(t, *dir)
 		})
 	}
 	patches.WriteFileWithPatches(doc, filename)

--- a/testmark.go
+++ b/testmark.go
@@ -72,5 +72,5 @@ type DirEnt struct {
 
 	// Children, recursively.
 	Children     map[string]*DirEnt
-	ChildrenList []DirEnt
+	ChildrenList []*DirEnt
 }


### PR DESCRIPTION
The way the indexing is built, siblings can end up missing from the ChildrenList. I'm not sure how.

```
$ go test ./...
--- FAIL: TestIndexingTree (0.00s)
    index_test.go:97: 
        error:
          values are not equal
        comment:
          one
        comment:
          list: [two three]
        comment:
          keys: [two three four]
        got:
          int(3)
        want:
          int(2)
        stack:
          /home/cjb/repos/warpforge/go-testmark/index_test.go:97
            qt.Check(t, len(dir.Children), qt.Equals, len(dir.ChildrenList),
                // If the lengths are equal then the map and list should contain entries with the same names.
                // We don't know if the dir entries are _actually_ equivalent but the test recurses above so it should be fine.
                qt.Commentf("%s", dir.Name),
                qt.Commentf("list: %v", names(dir.ChildrenList)),
                qt.Commentf("keys: %v", keys(dir.Children)),
            )
          /home/cjb/repos/warpforge/go-testmark/index_test.go:95
            assertChildren(t, child)
          /home/cjb/repos/warpforge/go-testmark/index_test.go:66
            assertChildren(t, *doc.DirEnt)
        
FAIL
FAIL	github.com/warpfork/go-testmark	0.003s
ok  	github.com/warpfork/go-testmark/testexec	(cached)
FAIL
```

Here's an absurdly large chunk of json that shows the structure of the failing bits.

`$ jq '{Name: .Name, Children: .Children.one, ChildrenList: .ChildrenList[] | select(.Name == "one")}'  log.json ` 
```json
{
  "Name": "",
  "Children": {
    "Name": "one",
    "Children": {
      "four": {
        "Name": "four",
        "Children": {
          "bang": {
            "Name": "bang",
            "Children": null,
            "ChildrenList": null
          }
        },
        "ChildrenList": [
          {
            "Name": "bang",
            "Children": null,
            "ChildrenList": null
          }
        ]
      },
      "three": {
        "Name": "three",
        "Children": null,
        "ChildrenList": null
      },
      "two": {
        "Name": "two",
        "Children": null,
        "ChildrenList": null
      }
    },
    "ChildrenList": [
      {
        "Name": "two",
        "Children": null,
        "ChildrenList": null
      },
      {
        "Name": "three",
        "Children": null,
        "ChildrenList": null
      },
      {
        "Name": "four",
        "Children": {
          "bang": {
            "Name": "bang",
            "Children": null,
            "ChildrenList": null
          }
        },
        "ChildrenList": [
          {
            "Name": "bang",
            "Children": null,
            "ChildrenList": null
          }
        ]
      }
    ]
  },
  "ChildrenList": {
    "Name": "one",
    "Children": {
      "four": {
        "Name": "four",
        "Children": {
          "bang": {
            "Name": "bang",
            "Children": null,
            "ChildrenList": null
          }
        },
        "ChildrenList": [
          {
            "Name": "bang",
            "Children": null,
            "ChildrenList": null
          }
        ]
      },
      "three": {
        "Name": "three",
        "Children": null,
        "ChildrenList": null
      },
      "two": {
        "Name": "two",
        "Children": null,
        "ChildrenList": null
      }
    },
    "ChildrenList": [
      {
        "Name": "two",
        "Children": null,
        "ChildrenList": null
      },
      {
        "Name": "three",
        "Children": null,
        "ChildrenList": null
      }
    ]
  }
}
```
